### PR TITLE
Update connect_for_documentation.py with automatic label

### DIFF
--- a/CLI (Linux) Multi-Session Connect Scripts/connect_for_documentation.py
+++ b/CLI (Linux) Multi-Session Connect Scripts/connect_for_documentation.py
@@ -154,7 +154,14 @@ def connect_volume(volume_name, target_iqn, target_portal_hostname, target_porta
         p.communicate()
             
     # maintain persistent connection
-    command = "sudo iscsiadm -m node --targetname {} --portal {}:{} --op update -n node.session.nr_sessions -v {}".format(target_iqn, target_portal_hostname, target_portal_port, number_of_sessions).split(' ')
+    command = "sudo iscsiadm -m node --targetname {} --portal {}:{} --op update -n node.session.nr_sessions " \
+              "-v {}".format(target_iqn, target_portal_hostname, target_portal_port, number_of_sessions).split(' ')
+    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p.communicate()
+
+    # automatic startup
+    command = "sudo iscsiadm -m node --targetname {} --portal {}:{} --op update -n node.startup -v automatic".format(
+        target_iqn, target_portal_hostname, target_portal_port).split(' ')
     p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     p.communicate()
 


### PR DESCRIPTION
## Purpose
```
Adds the automatic label to sessions so that they will be reestablished after machine reboots.
```

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ X] Other... Please describe: Changes script that is linked in documentation (https://learn.microsoft.com/en-us/azure/storage/elastic-san/elastic-san-connect-linux)
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
Follow the documentation steps to set up a Linux VM and Elastic SAN with 1 volume. 
Connect the volume to the Linux VM using the new script. 
Reboot the VM and check if the connection between the volume and VM still exist.
https://learn.microsoft.com/en-us/azure/storage/elastic-san/elastic-san-connect-linux
```

## What to Check
Verify that the following are valid
* ...
Connection to volume still exists after reboot.

## Other Information
<!-- Add any other helpful information that may be needed here. -->